### PR TITLE
Update datastructs.c

### DIFF
--- a/src/datastructs.c
+++ b/src/datastructs.c
@@ -30,7 +30,7 @@ popFromQueue(Queue *q){
         q->head = NULL;
     }
     q->size--;
-    free(poppedItem);
+
     return poppedLimit;
 }
 


### PR DESCRIPTION
Returning pointer to freed Limit, better to not free the poppedQueueItem at the place of the function call if sending the pointer back is important